### PR TITLE
Had the wrong link for `ha-mqtt-discoverable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 This repository contains CLI scripts for CRUD operations on MQTT entities that will be autodetected by Home Assistant.
 
-It is a group of wrappers for the [ha-mqtt-discoverable](https://github.com/unixorn/ha-mqtt-discoverable-cli) python module.
+It is a group of wrappers for the [ha-mqtt-discoverable](https://github.com/unixorn/ha-mqtt-discoverable) python module.
 
 ## Installing
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Stop self-linking, update to `ha-mqtt-discoverable`

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [x] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply as [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery-cli/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite a script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
